### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2017, conda-forge
+Copyright (c) 2015-2017, CLIVAR
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
The copyright was given to conda-forge in the original license, but it should probably be something like CLIVAR. Please propose an alternative copyright holder if CLIVAR is not correct.